### PR TITLE
[FIX] Criação de produto com tags

### DIFF
--- a/ormconfig.json
+++ b/ormconfig.json
@@ -9,5 +9,6 @@
     ],
     "cli": {
         "migrationsDir": "./src/database/migrations"
-    }
+    },
+    "synchronize": true
 }

--- a/src/controllers/ProductsController.ts
+++ b/src/controllers/ProductsController.ts
@@ -4,6 +4,7 @@ import * as Yup from 'yup';
 
 import productView from '../views/products_view';
 import ProductsRepository from '../repositories/ProductsRepository';
+import TagsRepository from '../repositories/TagsRepository';
 
 export default {
   async index(request: Request, response: Response) {
@@ -28,14 +29,19 @@ export default {
     return response.json(productView.render(product));
   },
 
+  /* TODO:
+   * O select na tabela Tags está pegando apenas 1 objeto,
+   * precisa ser modificado para buscar mais de uma.
+   */
   async create(request: Request, response: Response) {
-    
+
     const {
       name,
       price,
       amount,
       title,
       description,
+      tag,
     } = request.body;
 
     const productsRepository = getCustomRepository(ProductsRepository);
@@ -48,6 +54,10 @@ export default {
       }
     });
 
+    const tagsRepository = getCustomRepository(TagsRepository);
+
+    const tagModel = await tagsRepository.findOneOrFail({ tag });
+
     const productData = {
       name,
       price,
@@ -55,6 +65,7 @@ export default {
       title,
       description,
       images,
+      tags: [tagModel], // deve ser uma lista pois o orm espera uma lista de objeto
     };
 
     const schema = Yup.object().shape({
@@ -66,6 +77,7 @@ export default {
       images: Yup.array(Yup.object().shape({
         path: Yup.string().required(),
       })).max(5),
+      tag: Yup.string().required(),
     });
 
     await schema.validate(productData, { abortEarly: false });

--- a/src/models/Product.ts
+++ b/src/models/Product.ts
@@ -1,8 +1,8 @@
-import { Entity, Column, PrimaryColumn, OneToMany, JoinColumn } from 'typeorm';
+import { Entity, Column, PrimaryColumn, OneToMany, ManyToMany, JoinColumn, JoinTable } from 'typeorm';
 import { v4 as uuid } from 'uuid';
 
 import Image from './Image';
-import ProductTag from './ProductTag';
+import Tag from './Tag';
 
 @Entity('products')
 export default class Product {
@@ -31,11 +31,9 @@ export default class Product {
     @JoinColumn({ name: 'product_id' })
     images: Image[];
 
-    @OneToMany(() => ProductTag, productTag => productTag.product, {
-        cascade: ['insert', 'update']
-    })
-    @JoinColumn({ name: 'product_id' })
-    tags!: ProductTag[];
+    @ManyToMany(() => Tag)
+    @JoinTable()
+    tags: Tag[];
 
     constructor() {
         if(!this.id) {

--- a/src/models/Tag.ts
+++ b/src/models/Tag.ts
@@ -12,10 +12,6 @@ export default class Tag {
   @Column()
   tag: string;
 
-  @OneToMany(() => ProductTag, productTag => productTag.tag)
-  @JoinColumn({ name: 'tag_id' })
-  products: ProductTag[];
-
   constructor() {
     if(!this.id) {
         this.id = uuid();


### PR DESCRIPTION
# Descrição

Como o typeorm cria a tabela de relacionamento automaticamente, foi ajustado apenas o relacionamento entre as tabelas Product e Tag. O que foi necessário realizar para que funcione esta criação de tabela automatica, é a ativação da configuração "synchronize" (eles deveriam falar isso na lib, nem que seja um info dizendo "se não ativar esse carinha, não funciona).

No controller foi adicionado apenas um exemplo de criação de produto buscando a tag que foi passada na requisição.

# Melhorias

* Permitir que o usuário consiga adicionar diversas tags para o seu produto. Desta forma que está hoje, permite adicionar apenas uma tag por produto.
* Remover model ProductsTags e seus derivados (controller, entity, repository).

# Referências

* https://typeorm.io/#/relations
* https://typeorm.io/#/many-to-many-relations/
* https://stackoverflow.com/questions/55710824/sqlite-error-no-such-table-with-typeorm-on-a-connected-db-with-other-tables-a


#VAIIII